### PR TITLE
get -Werror off my back about cat_status

### DIFF
--- a/src/cat.c
+++ b/src/cat.c
@@ -1343,7 +1343,7 @@ static int validate_uint_range(struct cat_object *self, uint64_t val)
 static cat_status parse_write_args(struct cat_object *self)
 {
         int64_t val;
-        cat_status stat = 0;
+        cat_status stat;
 
         assert(self != NULL);
 
@@ -1394,6 +1394,9 @@ static cat_status parse_write_args(struct cat_object *self)
                         ack_error(self);
                         return CAT_STATUS_BUSY;
                 }
+                break;
+        default:
+                stat = 0;
                 break;
         }
 
@@ -1774,7 +1777,7 @@ static cat_status next_format_var_by_fsm(struct cat_object *self, cat_fsm_type f
 
 static cat_status format_read_args(struct cat_object *self, cat_fsm_type fsm)
 {
-        cat_status stat = 0;
+        cat_status stat;
 
         assert(self != NULL);
         assert(fsm < CAT_FSM_TYPE__TOTAL_NUM);
@@ -1801,6 +1804,9 @@ static cat_status format_read_args(struct cat_object *self, cat_fsm_type fsm)
                 break;
         case CAT_VAR_BUF_STRING:
                 stat = format_buffer_string(self, fsm);
+                break;
+        default:
+                stat = 0;
                 break;
         }
 

--- a/src/cat.c
+++ b/src/cat.c
@@ -1396,8 +1396,7 @@ static cat_status parse_write_args(struct cat_object *self)
                 }
                 break;
         default:
-                stat = 0;
-                break;
+                return CAT_STATUS_ERROR;
         }
 
         if ((self->var->write != NULL) && (self->var->write(self->var, self->write_size) != 0)) {
@@ -1806,8 +1805,7 @@ static cat_status format_read_args(struct cat_object *self, cat_fsm_type fsm)
                 stat = format_buffer_string(self, fsm);
                 break;
         default:
-                stat = 0;
-                break;
+                return CAT_STATUS_ERROR;
         }
 
         if (stat < 0) {

--- a/src/cat.c
+++ b/src/cat.c
@@ -1343,7 +1343,7 @@ static int validate_uint_range(struct cat_object *self, uint64_t val)
 static cat_status parse_write_args(struct cat_object *self)
 {
         int64_t val;
-        cat_status stat;
+        cat_status stat = 0;
 
         assert(self != NULL);
 
@@ -1774,7 +1774,7 @@ static cat_status next_format_var_by_fsm(struct cat_object *self, cat_fsm_type f
 
 static cat_status format_read_args(struct cat_object *self, cat_fsm_type fsm)
 {
-        cat_status stat;
+        cat_status stat = 0;
 
         assert(self != NULL);
         assert(fsm < CAT_FSM_TYPE__TOTAL_NUM);


### PR DESCRIPTION
my compiler doesn't like that its possible for stat to be uninitialized.
easiest way to fix that is (i think) to set it to 0 at the start.

-barrow