### PR TITLE
Allow linking with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories( ${PROJECT_SOURCE_DIR}/src )
 
 file( GLOB SRC_FILES src/*.c )
 add_library( cat SHARED ${SRC_FILES} )
+target_include_directories(cat INTERFACE ${CMAKE_CURRENT_LIST_DIR}/src)
 set_target_properties( cat PROPERTIES VERSION 0.10.1 SOVERSION 1 )
 target_compile_options( cat PRIVATE -Werror -Wall -Wextra -pedantic )
 


### PR DESCRIPTION
i'm working in an embedded context without the luxury of make install
and dynamic linking. making a call to target_include_directories lets
target_link_libraries(cat) in a dependant project provide the "cat.h"
import.