### PR TITLE
Added return after assert to silence error

### DIFF
--- a/src/cat.c
+++ b/src/cat.c
@@ -2195,6 +2195,7 @@ static cat_return_state call_cmd_read_by_fsm(struct cat_object *self, cat_fsm_ty
                 return cmd->read(cmd, (uint8_t*)get_unsolicited_buf(self), &self->unsolicited_fsm.position, get_unsolicited_buf_size(self));
         default:
                 assert(false);
+                return CAT_RETURN_STATE_ERROR;
         }
 }
 
@@ -2269,6 +2270,7 @@ static cat_return_state call_cmd_test_by_fsm(struct cat_object *self, cat_fsm_ty
                 return cmd->test(cmd, (uint8_t*)get_unsolicited_buf(self), &self->unsolicited_fsm.position, get_unsolicited_buf_size(self));
         default:
                 assert(false);
+                return CAT_RETURN_STATE_ERROR;
         }
 }
 


### PR DESCRIPTION
Added return after assert to silence warning/error observed on MinGW64 gcc 12.2 (control reaches end of non-void function). I'm not sure why this wasn't caught earlier (maybe tests were done with other compiler version), but in case assertions are inactive (NDEBUG) this is a good fallback. All tests still pass.