### PR TITLE
Extend allowed characters in commands

### DIFF
--- a/src/cat.c
+++ b/src/cat.c
@@ -561,7 +561,7 @@ static void prepare_search_command(struct cat_object *self)
 
 static int is_valid_cmd_name_char(const char ch)
 {
-        return (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || (ch == '+') || (ch == '#') || (ch == '$') || (ch == '@') || (ch == '_');
+        return (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || (ch == '+') || (ch == '#') || (ch == '$') || (ch == '@') || (ch == '_') || (ch == '%') || (ch == '&');
 }
 
 static int is_valid_dec_char(const char ch)


### PR DESCRIPTION
Extend allowed characters in commands. Some existing Bluetooth modules use ampersand and percent in AT commands. I'm trying to keep backwards compatability with existing modules, so these characters are needed. Examples of affected AT commands: AT&F, AT&W on Telit modules for factory reset and percent in "Nordic-proprietary commands" on nRF91 modules (see [here](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fref_at_commands%2FREF%2Fat_commands%2Fat_syntax.html)). All tests still pass, but I'm not sure how this could affect existing projects.
