### PR TITLE
Allow possibility to pass argument + add new type uint/hex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+coverage
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ add_executable( unsolicited example/unsolicited.c )
 # target_compile_options(unsolicited PRIVATE -g)
 target_link_libraries( unsolicited cat )
 
+add_executable( spi example/spi.c )
+target_link_libraries( spi cat )
+
 add_executable( test_parse tests/test_parse.c )
 target_link_libraries( test_parse cat )
 add_test( test_parse ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_parse )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,28 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 
-add_compile_options("$<$<CONFIG:DEBUG>:-g;-DDEBUG>")
+add_compile_options("$<$<CONFIG:DEBUG>:-g>")
+add_compile_options("$<$<CONFIG:TEST>:-v;-g;-coverage;-fprofile-arcs;-ftest-coverage>")
+
+add_link_options("$<$<CONFIG:TEST>:-v;-coverage>")
 
 enable_testing( )
 
 include_directories( ${PROJECT_SOURCE_DIR}/src )
 
 file( GLOB SRC_FILES src/*.c )
+
 add_library( cat SHARED ${SRC_FILES} )
 target_include_directories(cat INTERFACE ${CMAKE_CURRENT_LIST_DIR}/src)
+
 set_target_properties( cat PROPERTIES VERSION 0.10.1 SOVERSION 1 )
 target_compile_options( cat PRIVATE -Werror -Wall -Wextra -pedantic )
+
+message("-- cmake binary dir: ${CMAKE_BINARY_DIR}")
+message("-- project source dir: ${PROJECT_SOURCE_DIR}")
+message("-- src files: ${SRC_FILES}")
+message("-- cmake current list dir: ${CMAKE_CURRENT_LIST_DIR}")
+message("-- cmake runtime output dir: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
 install( TARGETS cat DESTINATION lib )
 install( FILES src/cat.h DESTINATION include/cat )
@@ -159,5 +170,27 @@ target_link_libraries( test_write_uhex cat )
 add_test( test_write_uhex ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_write_uhex )
 
 add_custom_target( check COMMAND ${CMAKE_CTEST_COMMAND} --verbose )
-add_custom_target( cleanall COMMAND rm -rf Makefile CMakeCache.txt CMakeFiles/ bin/ lib/ cmake_install.cmake CTestTestfile.cmake Testing/ )
+add_custom_target( cleanall COMMAND rm -rf Makefile CMakeCache.txt CMakeFiles/ bin/ lib/ cmake_install.cmake CTestTestfile.cmake Testing coverage/ )
 add_custom_target( uninstall COMMAND xargs rm < install_manifest.txt )
+
+# Create the gcov target. Run coverage tests with 'make gcov'
+add_custom_target(gcov    
+    COMMAND mkdir -p coverage
+    COMMAND lcov --zerocounters --directory ./CMakeFiles/cat.dir/src
+    COMMAND lcov --capture --initial --directory ./CMakeFiles/cat.dir/src --output-file ./coverage/coverage.lcov
+    COMMAND ${CMAKE_MAKE_PROGRAM} test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+add_custom_command(TARGET gcov
+    COMMAND echo "=================== GCOV ===================="
+    COMMAND cd CMakeFiles/cat.dir/src
+    COMMAND gcov -w -c -d -m cat.c.gcno
+    COMMAND cd ${PROJECT_SOURCE_DIR}
+    COMMAND lcov -c --directory ./CMakeFiles/cat.dir/src --output-file ./coverage/coverage.lcov
+    COMMAND mkdir -p coverage/html
+    COMMAND genhtml ./coverage/coverage.lcov -o ./coverage/html
+    )
+
+add_dependencies(gcov cat)
+# Make sure to clean up the coverage folder
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ add_executable( test_implicit_write tests/test_implicit_write.c )
 target_link_libraries( test_implicit_write cat )
 add_test( test_implicit_write ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_implicit_write )
 
+add_executable( test_write_uhex tests/test_write_uhex.c )
+target_link_libraries( test_write_uhex cat )
+add_test( test_write_uhex ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_write_uhex )
+
 add_custom_target( check COMMAND ${CMAKE_CTEST_COMMAND} --verbose )
 add_custom_target( cleanall COMMAND rm -rf Makefile CMakeCache.txt CMakeFiles/ bin/ lib/ cmake_install.cmake CTestTestfile.cmake Testing/ )
 add_custom_target( uninstall COMMAND xargs rm < install_manifest.txt )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 
-add_compile_options("$<$<CONFIG:DEBUG>:-g>")
+add_compile_options("$<$<CONFIG:DEBUG>:-g;-DDEBUG>")
 
 enable_testing( )
 

--- a/README.md
+++ b/README.md
@@ -214,4 +214,17 @@ while (1) {
 
 Define DEBUG preprocessor and add *-g* argument for debug
 
-    cmake -DCMAKE_BUILD_TYPE=Debug .
+```sh
+cmake -DCMAKE_BUILD_TYPE=Debug .
+```
+
+ ## Run code coverage
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=Test .
+make
+make gcov
+```
+
+The coverage is available in [./coverage/html/index.html](coverage/html/index.html)
+

--- a/README.md
+++ b/README.md
@@ -214,6 +214,4 @@ while (1) {
 
 Define DEBUG preprocessor and add *-g* argument for debug
 
-```cmake -DCMAKE_BUILD_TYPE=Debug .
-```
-
+    cmake -DCMAKE_BUILD_TYPE=Debug .

--- a/README.md
+++ b/README.md
@@ -209,3 +209,11 @@ while (1) {
 }
 
 ```
+
+## Enable DEBUG
+
+Define DEBUG preprocessor and add *-g* argument for debug
+
+```cmake -DCMAKE_BUILD_TYPE=Debug .
+```
+

--- a/example/demo.c
+++ b/example/demo.c
@@ -49,13 +49,13 @@ static int spi_write(const struct cat_command *cmd, const uint8_t *data, const s
 		return -1;
 	}
 	printf("WRITE SPI\n");
-	printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data);
+	printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
 	return 0;
 }
 
 static int spi_read(const struct cat_command *var, uint8_t *data, size_t *data_size, const size_t max_data_size) {
         printf("READ SPI\n");
-		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data);
+		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
         return 0;
 }
 

--- a/example/demo.c
+++ b/example/demo.c
@@ -31,93 +31,42 @@ SOFTWARE.
 
 #include "../src/cat.h"
 
-static int32_t speed;
-static uint16_t adr;
-static uint8_t x;
-static uint8_t y;
-static uint8_t bytes_buf[4];
-static char msg[16];
 static bool quit_flag;
 
-static int x_write(const struct cat_variable *var, size_t write_size)
-{
-        printf("x variable updated internally to: %u\n", x);
+
+struct spi_cmd_t {
+	uint8_t address;
+	uint16_t data;
+	unsigned char data_set_with_address;
+};
+
+struct spi_cmd_t spi_cmd; 
+
+
+static int spi_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+	if(spi_cmd.data_set_with_address == 0) {
+		printf("Set data before write\n");
+		return -1;
+	}
+	printf("WRITE SPI\n");
+	printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data);
+	return 0;
+}
+
+static int spi_read(const struct cat_command *var, uint8_t *data, size_t *data_size, const size_t max_data_size) {
+        printf("READ SPI\n");
+		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data);
         return 0;
 }
 
-static int y_write(const struct cat_variable *var, size_t write_size)
-{
-        printf("y variable updated internally to: %u\n", y);
-        return 0;
+static int SpiResetIndex(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+	spi_cmd.data_set_with_address = 0;
+	return 0;
 }
 
-static int msg_write(const struct cat_variable *var, size_t write_size)
-{
-        printf("msg variable updated %lu bytes internally to: <%s>\n", write_size, msg);
-        return 0;
-}
-
-static int speed_write(const struct cat_variable *var, size_t write_size)
-{
-        printf("speed variable updated internally to: %d\n", speed);
-        return 0;
-}
-
-static int adr_write(const struct cat_variable *var, size_t write_size)
-{
-        printf("adr variable updated internally to: 0x%04X\n", adr);
-        return 0;
-}
-
-static int bytesbuf_write(const struct cat_variable *var, size_t write_size)
-{
-        int i = 0;
-
-        printf("bytes_buf variable updated %lu bytes internally to: ", write_size);
-        for (i = 0; i < sizeof(bytes_buf); i++)
-                printf("%02X", bytes_buf[i]);
-        printf("\n");
-
-        return 0;
-}
-
-static int go_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num)
-{
-        int i = 0;
-
-        printf("<%s>: x=%d y=%d msg=%s @ speed=%d\n",
-                cmd->name,
-                *(uint8_t*)(cmd->var[0].data),
-                *(uint8_t*)(cmd->var[1].data),
-                msg,
-                speed
-        );
-
-        printf("<bytes>: ");
-        for (i = 0; i < sizeof(bytes_buf); i++)
-                printf("%02X", bytes_buf[i]);
-        printf("\n");
-        return 0;
-}
-
-static int set_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num)
-{
-        printf("<%s>: SET SPEED TO = %d\n",
-                cmd->name,
-                speed
-        );
-        return 0;
-}
-
-static int set_read(const struct cat_command *cmd, uint8_t *data, size_t *data_size, const size_t max_data_size)
-{
-        return 0;
-}
-
-static int test_run(const struct cat_command *cmd)
-{
-        printf("TEST: <%s>", cmd->name);
-        return 0;
+static int SpiSetIndex(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+	spi_cmd.data_set_with_address = 1;
+	return 0;
 }
 
 static int quit_run(const struct cat_command *cmd)
@@ -132,73 +81,46 @@ static int print_cmd_list(const struct cat_command *cmd)
         return CAT_RETURN_STATE_PRINT_CMD_LIST_OK;
 }
 
-static struct cat_variable go_vars[] = {
-        {
-                .type = CAT_VAR_UINT_DEC,
-                .data = &x,
-                .data_size = sizeof(x),
-                .write = x_write,
-                .name = "x"
-        },
-        {
-                .type = CAT_VAR_UINT_DEC,
-                .data = &y,
-                .data_size = sizeof(y),
-                .write = y_write,
-                .name = "y"
-        },
-        {
-                .type = CAT_VAR_BUF_STRING,
-                .data = msg,
-                .data_size = sizeof(msg),
-                .write = msg_write,
-                .name = "msg"
-        }
-};
-
-static struct cat_variable set_vars[] = {
-        {
-                .type = CAT_VAR_INT_DEC,
-                .data = &speed,
-                .data_size = sizeof(speed),
-                .write = speed_write,
-                .name = "speed"
-        },
+static struct cat_variable data_spi[] = {
         {
                 .type = CAT_VAR_NUM_HEX,
-                .data = &adr,
-                .data_size = sizeof(adr),
-                .write = adr_write,
-                .name = "address"
-        },
-        {
-                .type = CAT_VAR_BUF_HEX,
-                .data = &bytes_buf,
-                .data_size = sizeof(bytes_buf),
-                .write = bytesbuf_write,
-                .name = "buffer"
+                .data = &(spi_cmd.address),
+                .data_size = sizeof(spi_cmd.address),
+                .write = SpiResetIndex,
+				//.read = spi_read,
+                .name = "address",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }, {
+                .type = CAT_VAR_INT_DEC,
+                .data = &(spi_cmd.data),
+                .data_size = sizeof(spi_cmd.data),
+                .write = SpiSetIndex,
+				//.read = spi_read,
+                .name = "data",
+                .access = CAT_VAR_ACCESS_READ_WRITE
         }
 };
 
 static struct cat_command cmds[] = {
-        {
-                .name = "+GO",
-                .write = go_write,
-                .var = go_vars,
-                .var_num = sizeof(go_vars) / sizeof(go_vars[0]),
-                .need_all_vars = true
-        },
-        {
-                .name = "+SET",
-                .write = set_write,
-                .read = set_read,
-                .var = set_vars,
-                .var_num = sizeof(set_vars) / sizeof(set_vars[0]),
-        },
-        {
-                .name = "#TEST",
-                .run = test_run
-        },
+		{
+                .name           = "+SPI",
+                .description    = "Fill SPI buffer",
+                //.write          = spi_write,
+                //.read           = spi_read,
+                .var            = data_spi,
+                .var_num        = sizeof(data_spi) / sizeof(data_spi[0]),
+                .need_all_vars = false
+		},
+		{
+                .name           = "+SPIR",
+                .description    = "Read SPI from buffer",
+                .run           = spi_read
+		},
+		{
+                .name           = "+SPIW",
+                .description    = "Write SPI from buffer",
+                .run            = spi_write
+		},
         {
                 .name = "#HELP",
                 .run = print_cmd_list,

--- a/example/demo.c
+++ b/example/demo.c
@@ -31,42 +31,93 @@ SOFTWARE.
 
 #include "../src/cat.h"
 
+static int32_t speed;
+static uint16_t adr;
+static uint8_t x;
+static uint8_t y;
+static uint8_t bytes_buf[4];
+static char msg[16];
 static bool quit_flag;
 
-
-struct spi_cmd_t {
-	uint8_t address;
-	uint16_t data;
-	unsigned char data_set_with_address;
-};
-
-struct spi_cmd_t spi_cmd; 
-
-
-static int spi_write(const struct cat_command *cmd) {
-	if(spi_cmd.data_set_with_address == 0) {
-		printf("Set data before write\n");
-		return -1;
-	}
-	printf("WRITE SPI\n");
-	printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
-	return 0;
-}
-
-static int spi_read(const struct cat_command *cmd) {
-        printf("READ SPI\n");
-		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
+static int x_write(const struct cat_variable *var, size_t write_size)
+{
+        printf("x variable updated internally to: %u\n", x);
         return 0;
 }
 
-static int SpiResetIndex(const struct cat_variable *var, size_t write_size) {
-	spi_cmd.data_set_with_address = 0;
-	return 0;
+static int y_write(const struct cat_variable *var, size_t write_size)
+{
+        printf("y variable updated internally to: %u\n", y);
+        return 0;
 }
 
-static int SpiSetIndex(const struct cat_variable *var, size_t write_size) {
-	spi_cmd.data_set_with_address = 1;
-	return 0;
+static int msg_write(const struct cat_variable *var, size_t write_size)
+{
+        printf("msg variable updated %lu bytes internally to: <%s>\n", write_size, msg);
+        return 0;
+}
+
+static int speed_write(const struct cat_variable *var, size_t write_size)
+{
+        printf("speed variable updated internally to: %d\n", speed);
+        return 0;
+}
+
+static int adr_write(const struct cat_variable *var, size_t write_size)
+{
+        printf("adr variable updated internally to: 0x%04X\n", adr);
+        return 0;
+}
+
+static int bytesbuf_write(const struct cat_variable *var, size_t write_size)
+{
+        int i = 0;
+
+        printf("bytes_buf variable updated %lu bytes internally to: ", write_size);
+        for (i = 0; i < sizeof(bytes_buf); i++)
+                printf("%02X", bytes_buf[i]);
+        printf("\n");
+
+        return 0;
+}
+
+static int go_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num)
+{
+        int i = 0;
+
+        printf("<%s>: x=%d y=%d msg=%s @ speed=%d\n",
+                cmd->name,
+                *(uint8_t*)(cmd->var[0].data),
+                *(uint8_t*)(cmd->var[1].data),
+                msg,
+                speed
+        );
+
+        printf("<bytes>: ");
+        for (i = 0; i < sizeof(bytes_buf); i++)
+                printf("%02X", bytes_buf[i]);
+        printf("\n");
+        return 0;
+}
+
+static int set_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num)
+{
+        printf("<%s>: SET SPEED TO = %d\n",
+                cmd->name,
+                speed
+        );
+        return 0;
+}
+
+static int set_read(const struct cat_command *cmd, uint8_t *data, size_t *data_size, const size_t max_data_size)
+{
+        return 0;
+}
+
+static int test_run(const struct cat_command *cmd)
+{
+        printf("TEST: <%s>", cmd->name);
+        return 0;
 }
 
 static int quit_run(const struct cat_command *cmd)
@@ -81,42 +132,73 @@ static int print_cmd_list(const struct cat_command *cmd)
         return CAT_RETURN_STATE_PRINT_CMD_LIST_OK;
 }
 
-static struct cat_variable data_spi[] = {
+static struct cat_variable go_vars[] = {
         {
-                .type = CAT_VAR_UINT_HEX,
-                .data = &(spi_cmd.address),
-                .data_size = sizeof(spi_cmd.address),
-                .write = SpiResetIndex,
-                .name = "address",
-                .access = CAT_VAR_ACCESS_READ_WRITE
-        }, {
-                .type = CAT_VAR_UINT_HEX,
-                .data = &(spi_cmd.data),
-                .data_size = sizeof(spi_cmd.data),
-                .write = SpiSetIndex,
-                .name = "data",
-                .access = CAT_VAR_ACCESS_READ_WRITE
+                .type = CAT_VAR_UINT_DEC,
+                .data = &x,
+                .data_size = sizeof(x),
+                .write = x_write,
+                .name = "x"
+        },
+        {
+                .type = CAT_VAR_UINT_DEC,
+                .data = &y,
+                .data_size = sizeof(y),
+                .write = y_write,
+                .name = "y"
+        },
+        {
+                .type = CAT_VAR_BUF_STRING,
+                .data = msg,
+                .data_size = sizeof(msg),
+                .write = msg_write,
+                .name = "msg"
+        }
+};
+
+static struct cat_variable set_vars[] = {
+        {
+                .type = CAT_VAR_INT_DEC,
+                .data = &speed,
+                .data_size = sizeof(speed),
+                .write = speed_write,
+                .name = "speed"
+        },
+        {
+                .type = CAT_VAR_NUM_HEX,
+                .data = &adr,
+                .data_size = sizeof(adr),
+                .write = adr_write,
+                .name = "address"
+        },
+        {
+                .type = CAT_VAR_BUF_HEX,
+                .data = &bytes_buf,
+                .data_size = sizeof(bytes_buf),
+                .write = bytesbuf_write,
+                .name = "buffer"
         }
 };
 
 static struct cat_command cmds[] = {
-		{
-                .name           = "+SPI",
-                .description    = "Fill SPI buffer",
-                .var            = data_spi,
-                .var_num        = sizeof(data_spi) / sizeof(data_spi[0]),
-                .need_all_vars = false
-		},
-		{
-                .name           = "+SPIR",
-                .description    = "Read SPI from buffer",
-                .run           = spi_read
-		},
-		{
-                .name           = "+SPIW",
-                .description    = "Write SPI from buffer",
-                .run            = spi_write
-		},
+        {
+                .name = "+GO",
+                .write = go_write,
+                .var = go_vars,
+                .var_num = sizeof(go_vars) / sizeof(go_vars[0]),
+                .need_all_vars = true
+        },
+        {
+                .name = "+SET",
+                .write = set_write,
+                .read = set_read,
+                .var = set_vars,
+                .var_num = sizeof(set_vars) / sizeof(set_vars[0]),
+        },
+        {
+                .name = "#TEST",
+                .run = test_run
+        },
         {
                 .name = "#HELP",
                 .run = print_cmd_list,

--- a/example/demo.c
+++ b/example/demo.c
@@ -43,7 +43,7 @@ struct spi_cmd_t {
 struct spi_cmd_t spi_cmd; 
 
 
-static int spi_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+static int spi_write(const struct cat_command *cmd) {
 	if(spi_cmd.data_set_with_address == 0) {
 		printf("Set data before write\n");
 		return -1;
@@ -53,18 +53,18 @@ static int spi_write(const struct cat_command *cmd, const uint8_t *data, const s
 	return 0;
 }
 
-static int spi_read(const struct cat_command *var, uint8_t *data, size_t *data_size, const size_t max_data_size) {
+static int spi_read(const struct cat_command *cmd) {
         printf("READ SPI\n");
 		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
         return 0;
 }
 
-static int SpiResetIndex(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+static int SpiResetIndex(const struct cat_variable *var, size_t write_size) {
 	spi_cmd.data_set_with_address = 0;
 	return 0;
 }
 
-static int SpiSetIndex(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num) {
+static int SpiSetIndex(const struct cat_variable *var, size_t write_size) {
 	spi_cmd.data_set_with_address = 1;
 	return 0;
 }

--- a/example/demo.c
+++ b/example/demo.c
@@ -87,7 +87,6 @@ static struct cat_variable data_spi[] = {
                 .data = &(spi_cmd.address),
                 .data_size = sizeof(spi_cmd.address),
                 .write = SpiResetIndex,
-				//.read = spi_read,
                 .name = "address",
                 .access = CAT_VAR_ACCESS_READ_WRITE
         }, {
@@ -95,7 +94,6 @@ static struct cat_variable data_spi[] = {
                 .data = &(spi_cmd.data),
                 .data_size = sizeof(spi_cmd.data),
                 .write = SpiSetIndex,
-				//.read = spi_read,
                 .name = "data",
                 .access = CAT_VAR_ACCESS_READ_WRITE
         }
@@ -105,8 +103,6 @@ static struct cat_command cmds[] = {
 		{
                 .name           = "+SPI",
                 .description    = "Fill SPI buffer",
-                //.write          = spi_write,
-                //.read           = spi_read,
                 .var            = data_spi,
                 .var_num        = sizeof(data_spi) / sizeof(data_spi[0]),
                 .need_all_vars = false

--- a/example/demo.c
+++ b/example/demo.c
@@ -83,14 +83,14 @@ static int print_cmd_list(const struct cat_command *cmd)
 
 static struct cat_variable data_spi[] = {
         {
-                .type = CAT_VAR_NUM_HEX,
+                .type = CAT_VAR_UINT_HEX,
                 .data = &(spi_cmd.address),
                 .data_size = sizeof(spi_cmd.address),
                 .write = SpiResetIndex,
                 .name = "address",
                 .access = CAT_VAR_ACCESS_READ_WRITE
         }, {
-                .type = CAT_VAR_INT_DEC,
+                .type = CAT_VAR_UINT_HEX,
                 .data = &(spi_cmd.data),
                 .data_size = sizeof(spi_cmd.data),
                 .write = SpiSetIndex,

--- a/example/spi.c
+++ b/example/spi.c
@@ -1,0 +1,178 @@
+/*
+MIT License
+
+Copyright (c) 2019 Marcin Borowicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <assert.h>
+
+#include "../src/cat.h"
+
+static bool quit_flag;
+
+
+struct spi_cmd_t {
+	uint8_t address;
+	uint16_t data;
+	unsigned char data_set_with_address;
+};
+
+struct spi_cmd_t spi_cmd; 
+
+
+static int spi_write(const struct cat_command *cmd) {
+	if(spi_cmd.data_set_with_address == 0) {
+		printf("Set data before write\n");
+		return -1;
+	}
+	printf("WRITE SPI\n");
+	printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
+	return 0;
+}
+
+static int spi_read(const struct cat_command *cmd) {
+        printf("READ SPI\n");
+		printf("Address=0x%02hx, Value=%d(0x%04hx)\n", spi_cmd.address, spi_cmd.data, spi_cmd.data);
+        return 0;
+}
+
+static int SpiResetIndex(const struct cat_variable *var, size_t write_size) {
+	spi_cmd.data_set_with_address = 0;
+	return 0;
+}
+
+static int SpiSetIndex(const struct cat_variable *var, size_t write_size) {
+	spi_cmd.data_set_with_address = 1;
+	return 0;
+}
+
+static int quit_run(const struct cat_command *cmd)
+{
+        printf("QUIT: <%s>", cmd->name);
+        quit_flag = true;
+        return 0;
+}
+
+static int print_cmd_list(const struct cat_command *cmd)
+{
+        return CAT_RETURN_STATE_PRINT_CMD_LIST_OK;
+}
+
+static struct cat_variable data_spi[] = {
+        {
+                .type = CAT_VAR_UINT_HEX,
+                .data = &(spi_cmd.address),
+                .data_size = sizeof(spi_cmd.address),
+                .write = SpiResetIndex,
+                .name = "address",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }, {
+                .type = CAT_VAR_UINT_HEX,
+                .data = &(spi_cmd.data),
+                .data_size = sizeof(spi_cmd.data),
+                .write = SpiSetIndex,
+                .name = "data",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }
+};
+
+static struct cat_command cmds[] = {
+		{
+                .name           = "+SPI",
+                .description    = "Fill SPI buffer",
+                .var            = data_spi,
+                .var_num        = sizeof(data_spi) / sizeof(data_spi[0]),
+                .need_all_vars = false
+		},
+		{
+                .name           = "+SPIR",
+                .description    = "Read SPI from buffer",
+                .run           = spi_read
+		},
+		{
+                .name           = "+SPIW",
+                .description    = "Write SPI from buffer",
+                .run            = spi_write
+		},
+        {
+                .name = "#HELP",
+                .run = print_cmd_list,
+        },
+        {
+                .name = "#QUIT",
+                .run = quit_run
+        },
+
+};
+
+static char buf[128];
+
+static struct cat_command_group cmd_group = {
+        .cmd = cmds,
+        .cmd_num = sizeof(cmds) / sizeof(cmds[0]),
+};
+
+static struct cat_command_group *cmd_desc[] = {
+        &cmd_group
+};
+
+static struct cat_descriptor desc = {
+        .cmd_group = cmd_desc,
+        .cmd_group_num = sizeof(cmd_desc) / sizeof(cmd_desc[0]),
+
+        .buf = buf,
+        .buf_size = sizeof(buf)
+};
+
+static int write_char(char ch)
+{
+        putc(ch, stdout);
+        return 1;
+}
+
+static int read_char(char *ch)
+{
+        *ch = getc(stdin);
+        return 1;
+}
+
+static struct cat_io_interface iface = {
+        .read = read_char,
+        .write = write_char
+};
+
+int main(int argc, char **argv)
+{
+        struct cat_object at;
+
+        cat_init(&at, &desc, &iface, NULL);
+
+        while ((cat_service(&at) != 0) && (quit_flag == 0)) {};
+
+        printf("Bye!\n");
+
+        return 0;
+}

--- a/src/cat.c
+++ b/src/cat.c
@@ -1243,7 +1243,7 @@ static int parse_buffer_string(struct cat_object *self)
 
                 switch (state) {
                 case 0:
-                        if(ch != ',')
+                        if(ch == ',')
                                 return 2;
                         if (ch != '"')
                                 return -1;
@@ -1406,7 +1406,7 @@ static cat_status parse_write_args(struct cat_object *self)
         case CAT_VAR_UINT_HEX:
                 stat = parse_num_hexadecimal(self, (uint64_t *)&val);
                 if (stat < 0) {
-                        self->position=0;
+                        self->position--;
                         stat = parse_uint_decimal(self, (uint64_t *)&val);
                         if (stat < 0) {
                                 ack_error(self);

--- a/src/cat.c
+++ b/src/cat.c
@@ -1378,6 +1378,7 @@ static cat_status parse_write_args(struct cat_object *self)
 {
         int64_t val;
         cat_status stat;
+        uint8_t position;
 
         assert(self != NULL);
         switch (self->var->type) {
@@ -1404,9 +1405,10 @@ static cat_status parse_write_args(struct cat_object *self)
                 }
                 break;
         case CAT_VAR_UINT_HEX:
+                position=self->position;
                 stat = parse_num_hexadecimal(self, (uint64_t *)&val);
                 if (stat < 0) {
-                        self->position--;
+                        self->position=position;
                         stat = parse_uint_decimal(self, (uint64_t *)&val);
                         if (stat < 0) {
                                 ack_error(self);

--- a/src/cat.c
+++ b/src/cat.c
@@ -1414,10 +1414,6 @@ static cat_status parse_write_args(struct cat_object *self)
                                 ack_error(self);
                                 return CAT_STATUS_BUSY;
                         }
-                        if (stat<2 && validate_uint_range(self, val) != 0) {
-                                ack_error(self);
-                                return CAT_STATUS_BUSY;
-                        }
                 }
                 if (stat<2 && validate_uint_range(self, val) != 0) {
                         ack_error(self);

--- a/src/cat.h
+++ b/src/cat.h
@@ -47,6 +47,7 @@ typedef enum {
         CAT_VAR_INT_DEC = 0, /* decimal encoded signed integer variable */
         CAT_VAR_UINT_DEC, /* decimal encoded unsigned integer variable */
         CAT_VAR_NUM_HEX, /* hexadecimal encoded unsigned integer variable */
+        CAT_VAR_UINT_HEX,//Hexa if starts with 0x else uint
         CAT_VAR_BUF_HEX, /* asciihex encoded bytes array */
         CAT_VAR_BUF_STRING /* string variable */
 } cat_var_type;

--- a/tests/test_write_uhex.c
+++ b/tests/test_write_uhex.c
@@ -1,0 +1,246 @@
+/*
+MIT License
+
+Copyright (c) 2019 Marcin Borowicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <assert.h>
+
+#include "../src/cat.h"
+
+static char write_results[256];
+static char ack_results[256];
+
+static uint8_t var_8;
+static uint8_t var_8_index=0;
+static uint8_t var_8_array[3];
+static uint16_t var_16;
+static uint16_t var_16_index=0;
+static uint16_t var_16_array[3];
+static uint32_t var_32;
+static uint32_t var_32_index=0;
+static uint32_t var_32_array[3];
+
+static char const *input_text;
+static size_t input_index;
+
+static int cmd_write(const struct cat_command *cmd, const uint8_t *data, const size_t data_size, const size_t args_num)
+{
+        strcat(write_results, " CMD:");
+        strncat(write_results, data, data_size);
+        return 0;
+}
+
+static int var_first(const struct cat_variable *var, size_t write_size)
+{
+        var_8_array[var_8_index++] = var_8;
+        return 0;
+}
+
+static int var_second(const struct cat_variable *var, size_t write_size)
+{
+        var_16_array[var_16_index++] = var_16;
+        return 0;
+}
+
+static int var_third(const struct cat_variable *var, size_t write_size)
+{
+        var_32_array[var_32_index++] = var_32;
+        return 0;
+}
+
+static struct cat_variable vars_triple[] = {
+        {
+                .type = CAT_VAR_UINT_HEX,
+                .data = &var_8,
+                .data_size = sizeof(var_8),
+                .write = var_first,
+                .name = "var_8",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }, {
+                .type = CAT_VAR_UINT_HEX,
+                .data = &var_16,
+                .data_size = sizeof(var_16),
+                .write = var_second,
+                .name = "var_16",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }, {
+                .type = CAT_VAR_UINT_HEX,
+                .data = &var_32,
+                .data_size = sizeof(var_32),
+                .write = var_third,
+                .name = "var_32",
+                .access = CAT_VAR_ACCESS_READ_WRITE
+        }
+};
+
+static struct cat_command cmds[] = {
+        {
+                .name = "+TRP",
+                .write = cmd_write,
+
+                .var = vars_triple,
+                .var_num = sizeof(vars_triple) / sizeof(vars_triple[0]),
+                .need_all_vars = false
+        }
+};
+
+static char buf[128];
+
+static struct cat_command_group cmd_group = {
+        .cmd = cmds,
+        .cmd_num = sizeof(cmds) / sizeof(cmds[0]),
+};
+
+static struct cat_command_group *cmd_desc[] = {
+        &cmd_group
+};
+
+static struct cat_descriptor desc = {
+        .cmd_group = cmd_desc,
+        .cmd_group_num = sizeof(cmd_desc) / sizeof(cmd_desc[0]),
+
+        .buf = buf,
+        .buf_size = sizeof(buf)
+};
+
+static int write_char(char ch)
+{
+        char str[2];
+        str[0] = ch;
+        str[1] = 0;
+        strcat(ack_results, str);
+        return 1;
+}
+
+static int read_char(char *ch)
+{
+        if (input_index >= strlen(input_text))
+                return 0;
+
+        *ch = input_text[input_index];
+        input_index++;
+        return 1;
+}
+
+static struct cat_io_interface iface = {
+        .read = read_char,
+        .write = write_char
+};
+
+static void prepare_input(const char *text)
+{
+        input_text = text;
+        input_index = 0;
+
+        memset(var_8_array, 0, sizeof(var_8_array));
+        memset(var_16_array, 0, sizeof(var_16_array));
+        memset(var_32_array, 0, sizeof(var_32_array));
+        var_8_index = 0;
+        var_16_index = 0;
+        var_32_index = 0;
+
+        memset(ack_results, 0, sizeof(ack_results));
+        memset(write_results, 0, sizeof(write_results));
+}
+
+static const char test_case_1[] = "\nAT+TRP=0\nAT+TRP=aa\nAT+TRP=001\nAT+TRP=0x123\nAT+TRP=0x12\nAT+TRP=,1\n";
+static const char test_case_2[] = "\nAT+TRP=,0\nAT+TRP=,aa\nAT+TRP=,001\nAT+TRP=,0x12345\nAT+TRP=,0x123\nAT+TRP=,,1\n";
+static const char test_case_3[] = "\nAT+TRP=,,0\nAT+TRP=,,aa\nAT+TRP=,,001\nAT+TRP=,,0x123456789\nAT+TRP=,,0x12345678\nAT+TRP=,,\n";
+static const char test_case_4[] = "\nAT+TRP=0,,0\nAT+TRP=aa,,aa\nAT+TRP=001,,001\nAT+TRP=0x12,,0x123456789\nAT+TRP=0x12,,0x321\n";
+
+int main(int argc, char **argv)
+{
+        struct cat_object at;
+
+        cat_init(&at, &desc, &iface, NULL);
+
+        prepare_input(test_case_1);
+        while (cat_service(&at) != 0) {};
+
+        assert(strcmp(ack_results, "\nOK\n\nERROR\n\nOK\n\nERROR\n\nOK\n\nOK\n") == 0);
+        assert(strcmp(write_results, " CMD:0 CMD:001 CMD:0x12 CMD:,1") == 0);
+
+        assert(var_8_array[0] == 0);
+        assert(var_8_array[1] == 1);
+        assert(var_8_array[2] == 0x12);
+        assert(var_16_array[0] == 1);
+        assert(var_16_array[1] == 0);
+        assert(var_16_array[2] == 0);
+        assert(var_32_array[0] == 0);
+        assert(var_32_array[1] == 0);
+        assert(var_32_array[2] == 0);
+
+        prepare_input(test_case_2);
+        while (cat_service(&at) != 0) {};
+
+        assert(strcmp(ack_results, "\nOK\n\nERROR\n\nOK\n\nERROR\n\nOK\n\nOK\n") == 0);
+        assert(strcmp(write_results, " CMD:,0 CMD:,001 CMD:,0x123 CMD:,,1") == 0);
+
+        assert(var_8_array[0]   == 0);
+        assert(var_16_array[0]  == 0);
+        assert(var_32_array[0]  == 1);
+        assert(var_8_array[1]   == 0);
+        assert(var_16_array[1]  == 1);
+        assert(var_32_array[1]  == 0);
+        assert(var_8_array[2]   == 0);
+        assert(var_16_array[2]  == 0x123);
+        assert(var_32_array[2]  == 0);
+
+        prepare_input(test_case_3);
+        while (cat_service(&at) != 0) {};
+
+        assert(strcmp(ack_results, "\nOK\n\nERROR\n\nOK\n\nERROR\n\nOK\n\nERROR\n") == 0);
+        assert(strcmp(write_results, " CMD:,,0 CMD:,,001 CMD:,,0x12345678") == 0);
+
+        assert(var_8_array[0]   == 0);
+        assert(var_16_array[0]  == 0);
+        assert(var_32_array[0]  == 0);
+        assert(var_8_array[1]   == 0);
+        assert(var_16_array[1]  == 0);
+        assert(var_32_array[1]  == 1);
+        assert(var_8_array[2]   == 0);
+        assert(var_16_array[2]  == 0);
+        assert(var_32_array[2]  == 0x12345678);
+
+        prepare_input(test_case_4);
+        while (cat_service(&at) != 0) {};
+
+        assert(strcmp(ack_results, "\nOK\n\nERROR\n\nOK\n\nERROR\n\nOK\n") == 0);
+        assert(strcmp(write_results, " CMD:0,,0 CMD:001,,001 CMD:0x12,,0x321") == 0);
+
+        assert(var_8_array[0]   == 0);
+        assert(var_16_array[0]  == 0);
+        assert(var_32_array[0]  == 0);
+        assert(var_8_array[1]   == 1);
+        assert(var_16_array[1]  == 0);
+        assert(var_32_array[1]  == 1);
+        assert(var_8_array[2]   == 0x12);
+        assert(var_16_array[2]  == 0);
+        assert(var_32_array[2]  == 0x321);
+
+        return 0;
+}


### PR DESCRIPTION
Hi, great project! Thanks for sharing it!  
I added the possibility to pass an argument with ',,'.
For example with 
 `AT+SET=<DATA_1>,<DATA_2>`
we can set DATA_2 only with :  
`AT+SET=,DATA_2`

I also added a new type of data : *CAT_VAR_UINT_HEX* which could be an uint or HEX depending if the DATA starts with *0x* or not.

I added the *test_write_uhex.c* with some *AT tests* and *spi.c* as example.